### PR TITLE
Fixing

### DIFF
--- a/app/lib/pages/login.dart
+++ b/app/lib/pages/login.dart
@@ -180,8 +180,8 @@ class _LoginScreenState extends State<LoginScreen> {
             break;
           default:
             errorMessage = "An undefined Error happened.";
-            print('Error message: ${e.message}');
-            print('Error code: ${e.code}');
+          // print('Error message: ${e.message}');
+          // print('Error code: ${e.code}');
         }
         final error = SnackBar(content: Text(errorMessage!));
         ScaffoldMessenger.of(context).showSnackBar(error);

--- a/app/lib/pages/settings_page.dart
+++ b/app/lib/pages/settings_page.dart
@@ -39,7 +39,7 @@ class _SettingsPageState extends State<SettingsPage> {
     setState(() {});
   }
 
-//Add friend dialog, witch will show when user pushes 'Add new friend' floating button and witch will add new friend to database
+//Add friend dialog, which will show when user pushes 'Add new friend' floating button and witch will add new friend to database
   Future addFriendDialog() {
     final TextEditingController nameController = TextEditingController();
     final TextEditingController emailController = TextEditingController();
@@ -93,20 +93,31 @@ class _SettingsPageState extends State<SettingsPage> {
 
                     // Checking if there is an account tied to given email
                     // fetchSignInMethodsForEmail returns an array with sign-in methods the given email has
-                    // TODO: Error messages for when user gives a wrong email address (and maybe put this in database_utils)
-                    var accountExists = await FirebaseAuth.instance
-                        .fetchSignInMethodsForEmail(email)
-                        .then((value) {
-                      return value.isNotEmpty;
-                    });
+                    bool accountExists;
+                    try {
+                      accountExists = await FirebaseAuth.instance
+                          .fetchSignInMethodsForEmail(email)
+                          .then((value) {
+                        return value.isNotEmpty;
+                      });
+                    } on FirebaseAuthException {
+                      accountExists = false;
+                    }
 
-                    // Checking if the name is correct
-                    // Database is being queried only once for the friend details (I think)
-                    var namesMatch = false;
+                    // Checking if the name is correct and if so, uses the queried user as the "newFriend"
+                    // Database is being queried only once for the (possible) friend details (I think)
+                    bool namesMatch = false;
                     if (accountExists) {
                       newFriend = await DatabaseUtil.getUserByEmail(email);
                       namesMatch =
                           name.toLowerCase() == newFriend.name.toLowerCase();
+                    }
+
+                    // Error messages with SnackBar
+                    if (accountExists || !namesMatch) {
+                      final error =
+                          SnackBar(content: Text(wrong_name_or_email));
+                      ScaffoldMessenger.of(context).showSnackBar(error);
                     }
 
                     // Check if name and email are not empty and if not, adds friend
@@ -114,24 +125,6 @@ class _SettingsPageState extends State<SettingsPage> {
                         email.isNotEmpty &&
                         accountExists &&
                         namesMatch) {
-                      /*
-                      DatabaseReference db = database.ref().child('users/');
-
-                      // Querying for the correct user using their email address
-                      // Returns a DataSnapshot
-                      // Could be in database_utils
-                      DataSnapshot snapshot =
-                          await db.orderByChild('email').equalTo(email).get();
-
-                      String? friendUID = snapshot.children.first.key;
-
-                      Friend newFriend = Friend(
-                        name: name,
-                        email: email,
-                        uid: friendUID,
-                      );
-                      */
-
                       DatabaseUtil.addFriend(newFriend);
                       nameController.clear();
                       emailController.clear();

--- a/app/lib/pages/settings_page.dart
+++ b/app/lib/pages/settings_page.dart
@@ -89,6 +89,7 @@ class _SettingsPageState extends State<SettingsPage> {
                   onPressed: () async {
                     final name = nameController.text;
                     final email = emailController.text;
+                    Friend newFriend = Friend(name: '', email: '');
 
                     // Checking if there is an account tied to given email
                     // fetchSignInMethodsForEmail returns an array with sign-in methods the given email has
@@ -99,8 +100,21 @@ class _SettingsPageState extends State<SettingsPage> {
                       return value.isNotEmpty;
                     });
 
+                    // Checking if the name is correct
+                    // Database is being queried only once for the friend details (I think)
+                    var namesMatch = false;
+                    if (accountExists) {
+                      newFriend = await DatabaseUtil.getUserByEmail(email);
+                      namesMatch =
+                          name.toLowerCase() == newFriend.name.toLowerCase();
+                    }
+
                     // Check if name and email are not empty and if not, adds friend
-                    if (name.isNotEmpty && email.isNotEmpty && accountExists) {
+                    if (name.isNotEmpty &&
+                        email.isNotEmpty &&
+                        accountExists &&
+                        namesMatch) {
+                      /*
                       DatabaseReference db = database.ref().child('users/');
 
                       // Querying for the correct user using their email address
@@ -116,8 +130,9 @@ class _SettingsPageState extends State<SettingsPage> {
                         email: email,
                         uid: friendUID,
                       );
+                      */
 
-                      DatabaseUtil.addFriend(newFriend, friendUID);
+                      DatabaseUtil.addFriend(newFriend);
                       nameController.clear();
                       emailController.clear();
                       fetchList();

--- a/app/lib/properties.dart
+++ b/app/lib/properties.dart
@@ -38,6 +38,7 @@ const friend_add = "Add new friend";
 const friend_new = "Add a new friend using their email";
 const friend_email = "Email";
 const friend_name = "Friend's name";
+const wrong_name_or_email = "Wrong name or email address";
 
 //All groups-page's texts:
 const all_groups_caption = "All groups";

--- a/app/lib/utils/database_utils.dart
+++ b/app/lib/utils/database_utils.dart
@@ -52,20 +52,32 @@ class DatabaseUtil {
         email: value.child("email/").value.toString()));
   }
 
+  // Queries for the user using an email address
+  // Returns a Future<Friend> (use "await" to get "Friend" :] )
+  static Future<Friend> getUserByEmail(String email) async {
+    DatabaseReference db = database.ref().child('users/');
+    DataSnapshot snapshot = await db.orderByChild('email').equalTo(email).get();
+    Friend friend = Friend(
+        name: snapshot.children.first.child('username').value.toString(),
+        email: email,
+        uid: snapshot.children.first.key);
+    return friend;
+  }
+
   ///Add new friend to user's friend list
   /// [friend] is Friend object that will be added user's friend list
   /// [user] is the user who is adding the friend
-  static Future<void> addFriend(Friend friend, String? friendUID) async {
+  static Future<void> addFriend(Friend friend) async {
     final user = FirebaseAuth.instance.currentUser!;
     DatabaseReference ref = database.ref('users/${user.uid}/friends/');
 
     final data = {
       'name': friend.name,
       'email': friend.email,
-      'uid': friendUID,
+      'uid': friend.uid,
     };
 
-    await ref.child('$friendUID').set(data);
+    await ref.child('${friend.uid}').set(data);
   }
 
   ///Get list of friends from database


### PR DESCRIPTION
- Adding friends now requires friend's name and email address (name is not case sensitive).
  - Querying by email now happens in `database_utils` and should only be done once per attempted friend add
    - If query finds a valid user, it is also returned, not just used to prove a user exists
- Added error handling for wrong name and email address (doesn't specify which is wrong)
  - Uses `SnackBar`, doesn't look too good, but hey. It works :)